### PR TITLE
PDF Bug - The Sequel

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -51,9 +51,10 @@ def notices_updated(notices):
         }
         files = []
         if 'attachment_url' in notice:
-            r = requests.get(notice['attachment_url'], stream=True,
-                             **req_args)
-            r.raw.decode_content = True
+            r = notice['attachment_raw']
+            # r = requests.get(notice['attachment_url'], stream=True,
+            #                  **req_args)
+            # r.raw.decode_content = True
             filename = notice['attachment_url'].split('/')[-1]
             files = [('attachment', (filename, r.raw))]
 

--- a/hooks.py
+++ b/hooks.py
@@ -52,7 +52,7 @@ def notices_updated(notices):
         files = []
         if 'attachment_url' in notice:
             filename = notice['attachment_url'].split('/')[-1]
-            files = [('attachment', (filename, notice['attachment_raw'].raw))]
+            files = [('attachment', (filename, notice['attachment_raw']))]
 
         r = requests.post(
             'https://api.mailgun.net/v3/%s/messages' % env['MAILGUN_DOMAIN'],

--- a/hooks.py
+++ b/hooks.py
@@ -51,12 +51,8 @@ def notices_updated(notices):
         }
         files = []
         if 'attachment_url' in notice:
-            r = notice['attachment_raw']
-            # r = requests.get(notice['attachment_url'], stream=True,
-            #                  **req_args)
-            # r.raw.decode_content = True
             filename = notice['attachment_url'].split('/')[-1]
-            files = [('attachment', (filename, r.raw))]
+            files = [('attachment', (filename, notice['attachment_raw'].raw))]
 
         r = requests.post(
             'https://api.mailgun.net/v3/%s/messages' % env['MAILGUN_DOMAIN'],

--- a/update.py
+++ b/update.py
@@ -65,7 +65,7 @@ def check_notices(session, sessionData):
             r = session.get(notice['attachment_url'], stream=True)
             r.raw.decode_content = True
             hash_ = hashlib.md5()
-            notice['attachment_raw'] = ""
+            notice['attachment_raw'] = b""
             for chunk in r.iter_content(4096):
                 notice['attachment_raw'] += chunk
                 hash_.update(chunk)

--- a/update.py
+++ b/update.py
@@ -64,7 +64,7 @@ def check_notices(session, sessionData):
             notice['attachment_url'] = ERP_ATTACHMENT_URL + m.group(1)
             r = session.get(notice['attachment_url'], stream=True)
             r.raw.decode_content = True
-            notice['attachment_raw'] = r
+            notice['attachment_raw'] = r.raw
             hash_ = hashlib.md5()
 
             for chunk in iter(lambda: r.raw.read(4096), b""):

--- a/update.py
+++ b/update.py
@@ -63,10 +63,12 @@ def check_notices(session, sessionData):
             notice['attachment_url'] = ERP_ATTACHMENT_URL + m.group(1)
             r = session.get(notice['attachment_url'], stream=True)
             r.raw.decode_content = True
-            hash_ = hashlib.md5()
-            for chunk in iter(lambda: r.raw.read(4096), b""):
-                hash_.update(chunk)
-            notice['attachment_md5'] = hash_.hexdigest()
+            notice['attachment_raw'] = r
+            # hash_ = hashlib.md5()
+
+            # for chunk in iter(lambda: r.raw.read(4096), b""):
+            #     hash_.update(chunk)
+            # notice['attachment_md5'] = hash_.hexdigest()
 
         notices.append(notice)
 


### PR DESCRIPTION
### Le Conspiracy Theory

The code changes in the previous PR actually reflected in no apparent changes to MFTP as a service, because the issue was in the mailer function (`hooks.py`). The mailer was fetching the PDF's attachment URL and then reading it before sending to MailGun API.

Well, due to the recent update of the PDF portal, the PDF URL is no longer available directly without SSO (ERP login). (Yup, previously - the PDF URL was THE only non-SSO openly available URL being used in our script)

Hence, without providing any session details in the mailer script, `requests.get(pdf_url)` would simply return an auth error. I think this is what's been being written into our PDF files - error codes that are obviously not PDF content. Hence, the PDFs failed to open.