### PR TITLE
Add Metakgp branding to MFTP Mails

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -7,7 +7,7 @@ from erp import req_args
 
 if 'NOTICES_EMAIL_ADDRESS' not in env:
     env['NOTICES_EMAIL_ADDRESS'] = env['EMAIL_ADDRESS']
-METAKGP_BRANDING = "Brought To Your Inbox By <a href='https://www.github.com/metakgp'>Metakgp</a> With <3"
+METAKGP_BRANDING = "Brought To Your Inbox By <a href='https://metakgp.github.io'>Metakgp</a> With <3"
 
 
 def make_text(company):
@@ -50,7 +50,6 @@ def notices_updated(notices):
                                             notice['company']),
             'html': '<i>(%s)</i>: <p>%s</p><p>%s</p>' % (notice['time'], notice['text'], METAKGP_BRANDING),
         }
-        print(message)
         files = []
         if 'attachment_url' in notice:
             filename = notice['attachment_url'].split('/')[-1]

--- a/hooks.py
+++ b/hooks.py
@@ -7,6 +7,7 @@ from erp import req_args
 
 if 'NOTICES_EMAIL_ADDRESS' not in env:
     env['NOTICES_EMAIL_ADDRESS'] = env['EMAIL_ADDRESS']
+METAKGP_BRANDING = "Brought To Your Inbox By <a href='https://www.github.com/metakgp'>Metakgp</a> With <3"
 
 
 def make_text(company):
@@ -47,8 +48,9 @@ def notices_updated(notices):
             'fromname': 'MFTP',
             'subject': 'Notice: %s - %s' % (notice['subject'],
                                             notice['company']),
-            'html': '<i>(%s)</i>: <p>%s<p>' % (notice['time'], notice['text']),
+            'html': '<i>(%s)</i>: <p>%s</p><p>%s</p>' % (notice['time'], notice['text'], METAKGP_BRANDING),
         }
+        print(message)
         files = []
         if 'attachment_url' in notice:
             filename = notice['attachment_url'].split('/')[-1]

--- a/hooks.py
+++ b/hooks.py
@@ -7,7 +7,7 @@ from erp import req_args
 
 if 'NOTICES_EMAIL_ADDRESS' not in env:
     env['NOTICES_EMAIL_ADDRESS'] = env['EMAIL_ADDRESS']
-METAKGP_BRANDING = "Brought To Your Inbox By <a href='https://metakgp.github.io'>Metakgp</a> With <3"
+METAKGP_BRANDING = "Brought to you by <a href='https://metakgp.github.io'>Metakgp</a>"
 
 
 def make_text(company):
@@ -48,7 +48,7 @@ def notices_updated(notices):
             'fromname': 'MFTP',
             'subject': 'Notice: %s - %s' % (notice['subject'],
                                             notice['company']),
-            'html': '<i>(%s)</i>: <p>%s</p><p>%s</p>' % (notice['time'], notice['text'], METAKGP_BRANDING),
+            'html': '<i>(%s)</i>: <p>%s</p><br/><hr/><p style="color:#6c757d;">%s</p>' % (notice['time'], notice['text'], METAKGP_BRANDING),
         }
         files = []
         if 'attachment_url' in notice:


### PR DESCRIPTION
As discussed in the metakgp slack channel, we should brand the mails we sent through MFTP in order to reach more people and make them aware of us. This way we can also hope to get people involved in the process of contributing.