### PR TITLE
fix: handle URI max length exceeded

### DIFF
--- a/mftp/ntfy.py
+++ b/mftp/ntfy.py
@@ -51,6 +51,7 @@ def format_notices(notices):
             notice['Body'] = data
             notice.pop('BodyData', None)
             body, links = parse_links(data)
+            body = body[:5000] + '...\n\n[NOTICE SIZE EXCEEDED, PLEASE CHECK NOTICEBOARD]\n' if len(body) > 5000 else body
             body += '''
 --------------
 


### PR DESCRIPTION
# Description

ntfy returns 414 on exceeding max URI length (approx length of notice: 6000).
During formatting of notices, truncate notice body if size exceeds 5000 characters and add note to check noticeboard.

Bug can be reproduced by trying to PUT to the ntfy with length of message query exceeding 6000 characters
```
curl -X PUT https://ntfy.sh/{topic-name}\?message="{message exceeding length}"
```

## Type of change
Bug fix (non-breaking change which fixes an issue)
