### PR TITLE
feat: refactor email config to allow SMTP hosts other than Gmail

### DIFF
--- a/mftp/README.md
+++ b/mftp/README.md
@@ -230,11 +230,11 @@ _Now that the environment has been set up and configured to properly compile and
    - ##### Using SMTP
      > `--smtp`
      - [Create an app password](https://support.google.com/accounts/answer/185833?hl=en) for the senders' email.
-     - After creating app password use it as your `FROM_EMAIL_PASS` value in  next step.
+     - After creating app password use it as your `SMTP_PASS` value in  next step.
    - ##### Using GMAIL API
      > `--gmail-api`
      - Follow this [quick start guide](https://developers.google.com/gmail/api/quickstart/python) to configure _gmail api_ on the senders' mail.
-     - After successfull configuration of gmail api, you can leave the value of `FROM_EMAIL_PASS` as it is in the next step.
+     - After successfull configuration of gmail api, you can leave the value of `SMTP_PASS` as it is in the next step.
      - Save the generated token as `mail_send_token.json`
        
 4. #### Configuring environment variables

--- a/mftp/README.md
+++ b/mftp/README.md
@@ -230,11 +230,11 @@ _Now that the environment has been set up and configured to properly compile and
    - ##### Using SMTP
      > `--smtp`
      - [Create an app password](https://support.google.com/accounts/answer/185833?hl=en) for the senders' email.
-     - After creating app password use it as your `SMTP_PASS` value in  next step.
+     - After creating app password use it as your `FROM_EMAIL_PASS` value in  next step.
    - ##### Using GMAIL API
      > `--gmail-api`
      - Follow this [quick start guide](https://developers.google.com/gmail/api/quickstart/python) to configure _gmail api_ on the senders' mail.
-     - After successfull configuration of gmail api, you can leave the value of `SMTP_PASS` as it is in the next step.
+     - After successfull configuration of gmail api, you can leave the value of `FROM_EMAIL_PASS` as it is in the next step.
      - Save the generated token as `mail_send_token.json`
        
 4. #### Configuring environment variables

--- a/mftp/env.example.py
+++ b/mftp/env.example.py
@@ -46,10 +46,11 @@ ROLL_MAIL = {
 
 # EMAIL
 ## Senders' Credentials (via SMTP)
-SMTP_HOST = "smtp.gmail.com"
-SMTP_USER = "xxxxxxxxxxxxxxxxxxxx"  # Same as FROM_EMAIL in case of Gmail SMTP
-SMTP_PASS = "xxxxxxxxxxxxxxxxxxxx"  # App password in case of Gmail SMTP
 FROM_EMAIL = "abc@gmail.com" # Notification Sender Email-id
+# SMTP Credentials
+SMTP_HOST = "smtp.gmail.com"
+FROM_EMAIL_USER = "xxxxxxxxxxxxxxxxxxxx"  # Same as FROM_EMAIL in case of Gmail SMTP
+FROM_EMAIL_PASS = "xxxxxxxxxxxxxxxxxxxx"  # App password in case of Gmail SMTP
 ## EMAIL - Receiver's Address
 BCC_EMAIL_S = ["xyz@googlegroups.com", "abc@googlegroups.com"] # Multiple mails for bcc
 # BCC_EMAIL_S = ["xyz@googlegroups.com"] # This is how you can set single mail in a list

--- a/mftp/env.example.py
+++ b/mftp/env.example.py
@@ -46,8 +46,10 @@ ROLL_MAIL = {
 
 # EMAIL
 ## Senders' Credentials (via SMTP)
+SMTP_HOST = "smtp.gmail.com"
+SMTP_USER = "xxxxxxxxxxxxxxxxxxxx"  # Same as FROM_EMAIL in case of Gmail SMTP
+SMTP_PASS = "xxxxxxxxxxxxxxxxxxxx"  # App password in case of Gmail SMTP
 FROM_EMAIL = "abc@gmail.com" # Notification Sender Email-id
-FROM_EMAIL_PASS = "**********" # App password for the above email-id
 ## EMAIL - Receiver's Address
 BCC_EMAIL_S = ["xyz@googlegroups.com", "abc@googlegroups.com"] # Multiple mails for bcc
 # BCC_EMAIL_S = ["xyz@googlegroups.com"] # This is how you can set single mail in a list

--- a/mftp/mail.py
+++ b/mftp/mail.py
@@ -5,7 +5,7 @@ from endpoints import TPSTUDENT_URL
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
-from env import FROM_EMAIL, SMTP_HOST, SMTP_USER, SMTP_PASS, BCC_EMAIL_S, HOSTER_EMAIL, HOSTER_INTERESTED_ROLLS, HOSTER_NAME, ROLL_MAIL, ROLL_NAME
+from env import FROM_EMAIL, SMTP_HOST, FROM_EMAIL_USER, FROM_EMAIL_PASS, BCC_EMAIL_S, HOSTER_EMAIL, HOSTER_INTERESTED_ROLLS, HOSTER_NAME, ROLL_MAIL, ROLL_NAME
 
 
 def send_shortlists(mails, gmail_api, smtp):
@@ -41,7 +41,7 @@ def send_shortlists(mails, gmail_api, smtp):
         with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(SMTP_USER, SMTP_PASS)
+                server.login(FROM_EMAIL_USER, FROM_EMAIL_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")
@@ -176,7 +176,7 @@ def send_companies(mail, gmail_api, smtp):
         with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(SMTP_USER, SMTP_PASS)
+                server.login(FROM_EMAIL_USER, FROM_EMAIL_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")
@@ -290,7 +290,7 @@ def send_notices(mails, smtp, gmail_api, notice_db):
         with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(SMTP_USER, SMTP_PASS)
+                server.login(FROM_EMAIL_USER, FROM_EMAIL_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")

--- a/mftp/mail.py
+++ b/mftp/mail.py
@@ -5,7 +5,7 @@ from endpoints import TPSTUDENT_URL
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
-from env import FROM_EMAIL, FROM_EMAIL_PASS, BCC_EMAIL_S, HOSTER_EMAIL, HOSTER_INTERESTED_ROLLS, HOSTER_NAME, ROLL_MAIL, ROLL_NAME
+from env import FROM_EMAIL, SMTP_HOST, SMTP_USER, SMTP_PASS, BCC_EMAIL_S, HOSTER_EMAIL, HOSTER_INTERESTED_ROLLS, HOSTER_NAME, ROLL_MAIL, ROLL_NAME
 
 
 def send_shortlists(mails, gmail_api, smtp):
@@ -37,11 +37,11 @@ def send_shortlists(mails, gmail_api, smtp):
         import smtplib
         context = ssl.create_default_context()
 
-        logging.info(" [Connecting to smtp.google.com] ...")
-        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
+        logging.info(f" [Connecting to {SMTP_HOST}] ...")
+        with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(FROM_EMAIL, FROM_EMAIL_PASS)
+                server.login(SMTP_USER, SMTP_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")
@@ -172,11 +172,11 @@ def send_companies(mail, gmail_api, smtp):
         import smtplib
         context = ssl.create_default_context()
 
-        logging.info(" [Connecting to smtp.google.com] ...")
-        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
+        logging.info(f" [Connecting to {SMTP_HOST}] ...")
+        with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(FROM_EMAIL, FROM_EMAIL_PASS)
+                server.login(SMTP_USER, SMTP_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")
@@ -286,11 +286,11 @@ def send_notices(mails, smtp, gmail_api, notice_db):
         import smtplib
         context = ssl.create_default_context()
 
-        logging.info(" [Connecting to smtp.google.com] ...")
-        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
+        logging.info(f" [Connecting to {SMTP_HOST}] ...")
+        with smtplib.SMTP_SSL(SMTP_HOST, 465, context=context) as server:
             logging.info(" [Connected!]")
             try:
-                server.login(FROM_EMAIL, FROM_EMAIL_PASS)
+                server.login(SMTP_USER, SMTP_PASS)
                 logging.info(" [Logged In!]")
             except Exception as e:
                 logging.error(f" Failed to log in ~ {str(e)}")


### PR DESCRIPTION
# Description

Refactor the SMTP credentials to support SMTP hosts other than Gmail, like AWS SES.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
