### PR TITLE
Add deadline/test date parsing and Google Calendar export (#8)

### DIFF
--- a/scripts/generate_calendar_events.py
+++ b/scripts/generate_calendar_events.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+import dateparser
+import uuid
+
+def parse_date(text):
+    """Convert raw date text into a datetime object."""
+    return dateparser.parse(text)
+
+def create_ics_event(title, date):
+    """Create a .ics calendar file for Google Calendar."""
+    event_uid = str(uuid.uuid4())
+    dt_start = date.strftime("%Y%m%dT%H%M%S")
+    dt_end = (date + timedelta(hours=1)).strftime("%Y%m%dT%H%M%S")
+
+    content = f"""BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:{event_uid}
+DTSTAMP:{dt_start}
+DTSTART:{dt_start}
+DTEND:{dt_end}
+SUMMARY:{title}
+END:VEVENT
+END:VCALENDAR
+"""
+
+    filename = f"{title.replace(' ', '_')}.ics"
+    with open(filename, "w") as f:
+        f.write(content)
+
+    print(f"Created event file: {filename}")
+
+def process_events(event_list):
+    for event in event_list:
+        title = event["title"]
+        raw_date = event["date"]
+        parsed = parse_date(raw_date)
+        if parsed:
+            create_ics_event(title, parsed)
+        else:
+            print(f"Could not parse: {raw_date}")
+
+# Example test data
+events = [
+    {"title": "DSA Test", "date": "25 Jan 2025 at 3 PM"},
+    {"title": "Maths Assignment Deadline", "date": "30 Jan 2025"},
+]
+
+process_events(events)


### PR DESCRIPTION
This PR implements a beginner-friendly solution for Issue #8.

- Parses natural language dates using `dateparser`
- Generates .ics files for each test/deadline
- Files can be imported directly into Google Calendar
- No API keys required; works locally on any laptop

Example:
- DSA Test → 25 Jan 2025 at 3 PM
- Maths Assignment → 30 Jan 2025
