### PR TITLE
fix: substitute \u27e8 in ntfy request header with utf

### DIFF
--- a/mftp/ntfy.py
+++ b/mftp/ntfy.py
@@ -52,6 +52,7 @@ def format_notices(notices):
             notice.pop('BodyData', None)
             body, links = parse_links(data)
             body = body[:5000] + '...\n\n[NOTICE SIZE EXCEEDED, PLEASE CHECK NOTICEBOARD]\n' if len(body) > 5000 else body
+            body = body.replace('\u27e8', '<').replace('\u27e9', '>')
             body += '''
 --------------
 


### PR DESCRIPTION
# Description

```
ERROR:root: Failed to request NTFY SERVER: 'latin-1' codec can't encode character '\u27e8' in 
position 84:ordinal not in range(256)
```

## Type of change
Bug fix (non-breaking change which fixes an issue)
